### PR TITLE
feat!: support CSS-in-JS solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ pnpm add react-youtube
   videoId={string}                  // defaults -> ''
   id={string}                       // defaults -> ''
   className={string}                // defaults -> ''
-  containerClassName={string}       // defaults -> ''
+  iframeClassName={string}          // defaults -> ''
   containerStyle={object}           // defaults -> {}
   title={string}                    // defaults -> ''
   loading={string}                  // defaults -> undefined

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pnpm add react-youtube
   id={string}                       // defaults -> ''
   className={string}                // defaults -> ''
   iframeClassName={string}          // defaults -> ''
-  containerStyle={object}           // defaults -> {}
+  style={object}                    // defaults -> {}
   title={string}                    // defaults -> ''
   loading={string}                  // defaults -> undefined
   opts={obj}                        // defaults -> {}

--- a/packages/react-youtube/src/YouTube.tsx
+++ b/packages/react-youtube/src/YouTube.tsx
@@ -53,7 +53,7 @@ function shouldResetPlayer(prevProps: YouTubeProps, props: YouTubeProps) {
 }
 
 /**
- * Check whether a props change should result in an id or className update.
+ * Check whether a props change should result in an update of player.
  */
 function shouldUpdatePlayer(prevProps: YouTubeProps, props: YouTubeProps) {
   return (
@@ -61,6 +61,7 @@ function shouldUpdatePlayer(prevProps: YouTubeProps, props: YouTubeProps) {
     prevProps.className !== props.className ||
     prevProps.opts?.width !== props.opts?.width ||
     prevProps.opts?.height !== props.opts?.height ||
+    prevProps.iframeClassName !== props.iframeClassName ||
     prevProps.title !== props.title
   );
 }
@@ -97,11 +98,11 @@ export type YouTubeProps = {
    */
   className?: string;
   /**
-   * Custom class name for the player container element
+   * Custom class name for the iframe element
    */
-  containerClassName?: string;
+  iframeClassName?: string;
   /**
-   * Custom styles for the player container element
+   * Custom style for the player container element
    */
   containerStyle?: React.CSSProperties;
   /**
@@ -161,7 +162,7 @@ const defaultProps: YouTubeProps = {
   videoId: '',
   id: '',
   className: '',
-  containerClassName: '',
+  iframeClassName: '',
   containerStyle: {},
   title: '',
   loading: undefined,
@@ -180,7 +181,7 @@ const propTypes = {
   videoId: PropTypes.string,
   id: PropTypes.string,
   className: PropTypes.string,
-  containerClassName: PropTypes.string,
+  iframeClassName: PropTypes.string,
   containerStyle: PropTypes.object,
   title: PropTypes.string,
   loading: PropTypes.oneOf(['lazy', 'eager']),
@@ -340,7 +341,7 @@ class YouTube extends React.Component<YouTubeProps> {
     this.internalPlayer?.getIframe().then((iframe) => {
       if (this.props.id) iframe.setAttribute('id', this.props.id);
       else iframe.removeAttribute('id');
-      if (this.props.className) iframe.setAttribute('class', this.props.className);
+      if (this.props.iframeClassName) iframe.setAttribute('class', this.props.iframeClassName);
       else iframe.removeAttribute('class');
       if (this.props.opts && this.props.opts.width) iframe.setAttribute('width', this.props.opts.width.toString());
       else iframe.removeAttribute('width');
@@ -402,8 +403,8 @@ class YouTube extends React.Component<YouTubeProps> {
 
   render() {
     return (
-      <div className={this.props.containerClassName} style={this.props.containerStyle}>
-        <div id={this.props.id} className={this.props.className} ref={this.refContainer} />
+      <div className={this.props.className} style={this.props.containerStyle}>
+        <div id={this.props.id} className={this.props.iframeClassName} ref={this.refContainer} />
       </div>
     );
   }

--- a/packages/react-youtube/src/YouTube.tsx
+++ b/packages/react-youtube/src/YouTube.tsx
@@ -104,7 +104,7 @@ export type YouTubeProps = {
   /**
    * Custom style for the player container element
    */
-  containerStyle?: React.CSSProperties;
+  style?: React.CSSProperties;
   /**
    * Title of the video for the iframe's title tag.
    */
@@ -163,7 +163,7 @@ const defaultProps: YouTubeProps = {
   id: '',
   className: '',
   iframeClassName: '',
-  containerStyle: {},
+  style: {},
   title: '',
   loading: undefined,
   opts: {},
@@ -182,7 +182,7 @@ const propTypes = {
   id: PropTypes.string,
   className: PropTypes.string,
   iframeClassName: PropTypes.string,
-  containerStyle: PropTypes.object,
+  style: PropTypes.object,
   title: PropTypes.string,
   loading: PropTypes.oneOf(['lazy', 'eager']),
   opts: PropTypes.objectOf(PropTypes.any),
@@ -403,7 +403,7 @@ class YouTube extends React.Component<YouTubeProps> {
 
   render() {
     return (
-      <div className={this.props.className} style={this.props.containerStyle}>
+      <div className={this.props.className} style={this.props.style}>
         <div id={this.props.id} className={this.props.iframeClassName} ref={this.refContainer} />
       </div>
     );

--- a/packages/react-youtube/src/Youtube.test.tsx
+++ b/packages/react-youtube/src/Youtube.test.tsx
@@ -29,6 +29,19 @@ describe('YouTube', () => {
     expect(queryByAttribute('class', container, 'custom-class')).toBeDefined();
   });
 
+  it('should render an iframe with a custom class name', () => {
+    const { container } = render(<YouTube iframeClassName="custom-frame-class" videoId="XxVg_s8xAms" />);
+
+    expect(queryByAttribute('class', container, 'custom-frame-class')).toBeDefined();
+  });
+
+  it("should update iframe class name once it's changed", () => {
+    const { container, rerender } = render(<YouTube iframeClassName="custom-frame-class" videoId="XxVg_s8xAms" />);
+
+    rerender(<YouTube iframeClassName="custom-frame-class-2" videoId="XxVg_s8xAms" />);
+    expect(queryByAttribute('class', container, 'custom-frame-class-2')).toBeDefined();
+  });
+
   it('should update an id', () => {
     const { rerender } = render(<YouTube id="custom-id" videoId="XxVg_s8xAms" />);
 


### PR DESCRIPTION
# Description
Make component compatible with [emotion](https://emotion.sh) and [styled-components](https://www.styled-components.com) providing the className for parent element.

# Motivation
Previously this component wasn't compatible neither with [emotion css in js](https://emotion.sh) nor [styled-components](https://www.styled-components.com) due to the class name being set for child element.

## Notes
Duplicated by #209 