### PR TITLE
feat: getInternalPlayer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -62,4 +62,5 @@ export default class YouTube extends React.Component<YouTubeProps> {
         BUFFERING: 3,
         CUED: 5,
     };
+    getInternalPlayer(): YT.Player;
 }

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -217,6 +217,13 @@ class YouTube extends React.Component {
   };
 
   /**
+   *  Method to return the internalPlayer object.
+   */
+  getInternalPlayer = () => {
+    return this.internalPlayer;
+  };
+
+  /**
    * Call YouTube Player API methods to update the currently playing video.
    * Depending on the `opts.playerVars.autoplay` this function uses one of two
    * YouTube Player API methods to update the video.


### PR DESCRIPTION
Hey,

I've created a PR to fix a problem with this package and typescript.

**Problem:**
In a react app with TypeScript I pass a reference to the YouTube element to control the player. Getting the player by the `onReady` event did not work because the player is a state of the component.

Controlling the YouTube player with the reference does not work in TypeScript due to missing type definitions and this issue here https://github.com/tjallingt/react-youtube/issues/211

How to use the method:
```typescript
const playerRef = React.useRef<YouTube>(null)
const triggerPlay = React.useCallback(() => {
    if (playerRef && playerRef.current) {
      playerRef.current.getInternalPlayer().playVideo()
    }
  }, [playerRef])
```

**Description of changes:**
Adds a method to access the `internalPlayer` object and the corresponding type definiton in `index.d.ts`

**Related issues:**
https://github.com/tjallingt/react-youtube/issues/211

Thank you for this package 👍  Meanwhile we're going to work with our fork of this package