### PR TITLE
chore: fix 'Initializers are not allowed in ambient contexts.' ts error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,12 +54,12 @@ export interface YouTubeProps {
 }
 
 export default class YouTube extends React.Component<YouTubeProps> {
-    static PlayerState = {
-        UNSTARTED: -1,
-        ENDED: 0,
-        PLAYING: 1,
-        PAUSED: 2,
-        BUFFERING: 3,
-        CUED: 5,
+    static PlayerState: {
+        UNSTARTED: number,
+        ENDED: number,
+        PLAYING: number,
+        PAUSED: number,
+        BUFFERING: number,
+        CUED: number,
     };
 }


### PR DESCRIPTION
Typescript 3.8 was giving a following error in `index.d.ts` of the lib:
![Screen Shot 2020-04-23 at 9 10 36](https://user-images.githubusercontent.com/3503252/80065375-aa511e00-8542-11ea-857e-ff034c90fc79.png)

This PR removes initialisers from type definitions to fix the error