### PR TITLE
Use correct type definition for youtube player instead of  any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { YouTubePlayer } from 'youtube-player/dist/types';
 
 export interface PlayerVars {
   autoplay?: 0 | 1;
@@ -37,14 +38,14 @@ export interface YouTubeProps {
   className?: string;
   containerClassName?: string;
   opts?: Options;
-  onReady?(event: { target: YT.Player }): void;
-  onError?(event: { target: YT.Player; data: number }): void;
-  onPlay?(event: { target: YT.Player; data: number }): void;
-  onPause?(event: { target: YT.Player; data: number }): void;
-  onEnd?(event: { target: YT.Player; data: number }): void;
-  onStateChange?(event: { target: YT.Player; data: number }): void;
-  onPlaybackRateChange?(event: { target: YT.Player; data: number }): void;
-  onPlaybackQualityChange?(event: { target: YT.Player; data: string }): void;
+  onReady?(event: { target: YouTubePlayer }): void;
+  onError?(event: { target: YouTubePlayer; data: number }): void;
+  onPlay?(event: { target: YouTubePlayer; data: number }): void;
+  onPause?(event: { target: YouTubePlayer; data: number }): void;
+  onEnd?(event: { target: YouTubePlayer; data: number }): void;
+  onStateChange?(event: { target: YouTubePlayer; data: number }): void;
+  onPlaybackRateChange?(event: { target: YouTubePlayer; data: number }): void;
+  onPlaybackQualityChange?(event: { target: YouTubePlayer; data: string }): void;
 }
 
 export default class YouTube extends React.Component<YouTubeProps> {
@@ -56,5 +57,5 @@ export default class YouTube extends React.Component<YouTubeProps> {
     BUFFERING: number;
     CUED: number;
   };
-  getInternalPlayer(): YT.Player;
+  getInternalPlayer(): YouTubePlayer;
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@testing-library/jest-dom": "5.11.4",
     "@testing-library/react": "10.4.9",
     "@types/youtube": "0.0.39",
+    "@types/youtube-player": "5.5.3",
     "babel-eslint": "10.1.0",
     "babel-jest": "26.3.0",
     "babel-loader": "8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1796,6 +1796,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/youtube-player@5.5.3":
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/@types/youtube-player/-/youtube-player-5.5.3.tgz#84c450c766e19bda507a37e617e288a8ece3450c"
+  integrity sha512-G9k9Q8fyOwzX4A8DI90WB2viYlpxDazoLZDe37GY9+82JL2OOFhEzz6yUIKEt4klACdx/UUuY0BesD68BVR7SA==
+
 "@types/youtube@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/youtube/-/youtube-0.0.39.tgz#1c80e882d339a4d89da16b10acc411ceadc26955"


### PR DESCRIPTION
### Description
In [index.d.ts](https://github.com/tjallingt/react-youtube/blob/canary/index.d.ts#L59), `getInternalPlayer` reutns `YT.Player` type, but it is actually `any`. We should use [`@types/youtube-player`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/youtube-player/dist/types.d.ts#L47) instead of `YT.Player`.

### Before
`getInternalPlayer()` returns `any`.

![image](https://user-images.githubusercontent.com/17107119/95351305-0c88ba00-08fc-11eb-83fc-6d709eafd2cd.png)

### After
`getInternalPlayer()` returns correct type.

![image](https://user-images.githubusercontent.com/17107119/95351434-2de9a600-08fc-11eb-8d38-f98cc7d23452.png)
