### PR TITLE
chore(types): add cc_lang_pref to index.d.ts file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import { YouTubePlayer } from 'youtube-player/dist/types';
 
 export interface PlayerVars {
   autoplay?: 0 | 1;
+  cc_lang_pref?: string;
   cc_load_policy?: 1;
   color?: 'red' | 'white';
   controls?: 0 | 1 | 2;


### PR DESCRIPTION
Hello, I noticed the `cc_lang_pref` option was missing from the type definition and wanted to add it.

See https://developers.google.com/youtube/player_parameters#Parameters for details